### PR TITLE
Atomically claim relay flag to prevent duplicate Discord notifications

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -444,15 +444,28 @@ async function relay(
     webhookUrl: string,
     data: { allowed_mentions: { parse: string[] }; content: string },
 ) {
-    const response = await fetch(webhookUrl, {
-        method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-        },
-        body: JSON.stringify(data),
-    });
-    console.log(`Webhook response: ${response.status} ${await response.text()}`);
-    await context.redis.hSet(item.id, {relayed: "true"});
+    // Atomically claim "relayed" before firing the webhook to prevent
+    // duplicate relays in case multiple events are fired for the same item.
+    const claimed = await context.redis.hSetNX(item.id, "relayed", "true");
+    if (claimed === 0) {
+        console.log(`Skipping duplicate relay for ${item.id}: already relayed or being relayed by another worker`);
+        return;
+    }
+    try {
+        const response = await fetch(webhookUrl, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(data),
+        });
+        console.log(`Webhook response: ${response.status} ${await response.text()}`);
+    } catch (err) {
+        // Webhook fetch failed (e.g. network error). Roll back the claim so
+        // that the retry-on-approval path can attempt again.
+        await context.redis.hDel(item.id, ["relayed"]);
+        throw err;
+    }
 }
 
 async function scheduleRelay(context: TriggerContext, item: Comment | Post, approvalRetry: boolean) {


### PR DESCRIPTION
## Summary

Fixes a race condition in `relay()` that can cause duplicate Discord notifications when the same Reddit event is delivered to the app more than once.

## The bug

The deduplication in `relay()` is a non-atomic check-then-act:

- `shouldRelay()` reads `redis.hGet(item.id, "relayed")` early in the trigger handler (`src/main.ts:592` on current `master`).
- The corresponding `redis.hSet(item.id, {relayed: "true"})` only runs *after* the Discord webhook fetch completes (`src/main.ts:455` on current `master`).

The window between read and write spans an `item.getAuthor()` API call, several settings reads, and the Discord webhook HTTP round-trip — easily several hundred milliseconds.

When the same event is delivered more than once within that window — which currently happens in practice on Reddit's side (see Context below) — every invocation independently passes the `relayed === "true"` check, every one calls `relay()`, every one POSTs to the Discord webhook, and only afterwards do they all set the flag. Result: multiple Discord messages for one Reddit event.

This is most easily reproduced with `relay-mode = "immediately"` and `skip-safety-checks = true`, because that path has no other dedup gate (the `scheduled` flag is only consulted in the `delay > 0` branch of `scheduleRelay`). But the race exists for all configurations.

This is the same class of bug that 2.0.3 attempted to fix; that change introduced the current check-then-act pattern but didn't make it atomic.

## The fix

Use `hSetNX` to atomically claim the `relayed` flag *before* firing the webhook. If the claim fails (`hSetNX` returns 0), another invocation already has it, so abort. If the webhook fetch throws (network error), roll back the claim with `hDel` so the existing retry-on-approval path still works for genuine network failures.

```ts
const claimed = await context.redis.hSetNX(item.id, "relayed", "true");
if (claimed === 0) {
    console.log(`Skipping duplicate relay for ${item.id}: already relayed`);
    return;
}
try {
    const response = await fetch(webhookUrl, { ... });
    console.log(`Webhook response: ${response.status} ${await response.text()}`);
} catch (err) {
    await context.redis.hDel(item.id, ["relayed"]);
    throw err;
}
```

## Behavior preservation

- **Successful relays**: `relayed` field is `"true"` afterward, same as before.
- **HTTP error responses (4xx/5xx)**: `fetch` does not throw, so the flag remains set, same as before.
- **Network error / fetch throws**: flag is rolled back so the retry-on-approval path can fire later, matching the prior behavior where a thrown `fetch` left the flag unset.
- **`ModAction` retry-on-approval**: still gated on `wasRelayed` in the ModAction trigger, unchanged.

## Verified in playtest

Tested under a forked test-app installation on a freshly created small test subreddit, with `relay-mode = "immediately"` and `skip-safety-checks = true`. Across three test posts, every post produced 3-4 `PostSubmit` deliveries from Reddit but exactly one Discord webhook POST per post:

```
[remote] Received PostSubmit event (t3_xxxxx) by u/<redacted>
[remote] Received PostSubmit event (t3_xxxxx) by u/<redacted>
[remote] Received PostSubmit event (t3_xxxxx) by u/<redacted>
[remote] Received PostSubmit event (t3_xxxxx) by u/<redacted>
[remote] Should relay event: true   (× 4 — all four passed the non-atomic check)
[remote] Relaying event t3_xxxxx    (× 4 — all four entered relay())
[remote] Skipping duplicate relay for t3_xxxxx: already relayed  (× 3)
[remote] Webhook response: 204      (× 1)
```

Without this fix, the same conditions would have produced four Discord messages.

## Context

This race is being exposed in practice because Reddit currently delivers each trigger event to apps multiple times. A Reddit admin has acknowledged the upstream behavior in https://www.reddit.com/r/Devvit/comments/1t6vdbh/triggers_firing_3_times_for_same_event/, but the fix here is worth having regardless: the dedup the app already relies on was being violated by its own non-atomic check-then-act, and any future condition that delivers the same event twice in a tight window would re-expose the same bug.

## Reported by

JapanFinance subreddit moderators were seeing intermittent duplicate notifications with `relay-mode = "immediately"` and `skip-safety-checks = true`, with no recent configuration changes — consistent with this latent race being exposed by upstream event-delivery behavior.