### PR TITLE
Ignore .env and .env.local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 temp.*
+.env
+.env.local


### PR DESCRIPTION
Adds `.env` and `.env.local` to `.gitignore`.

Reddit's Devvit [multiple-developers guide](https://developers.reddit.com/docs/guides/tools/multiple_developers) recommends that contributors who don't own the upstream app override `DEVVIT_APP_NAME` (and optionally `DEVVIT_SUBREDDIT`) via a local `.env` file during `devvit playtest`, rather than editing `devvit.json`. The doc explicitly says:

> use a local `.env` file and ensure it's not committed by adding it to `.gitignore`.

Without this entry, a contributor following that workflow risks `git add`-ing their personal `.env` and leaking their test app name into a PR. This change is hygiene only — no source changes.